### PR TITLE
Added support for alternate return pattern to entry-points rules

### DIFF
--- a/lib/rules/entry-points.js
+++ b/lib/rules/entry-points.js
@@ -62,24 +62,14 @@ module.exports = {
         }
 
         if (returnArgument && returnArgument.type === 'Identifier') {
-          for (let i = 0; i < callbackBody.length; i++) {
-            const childNode = callbackBody[i];
-
-            if (childNode.type !== 'ExpressionStatement') {
-              continue;
-            }
-
-            const expressionLeft = childNode.expression.left;
-
-            if (
-              expressionLeft.object.name === returnArgument.name &&
-              scriptTypeMap[scriptType].entryPoints.includes(expressionLeft.property.name) &&
-              (expressionLeft.property.type === 'Identifier' ||
-              expressionLeft.property.type === 'FunctionExpression')
-            ) {
-              hasValidEntryPoint = true;
-              break;
-            }
+          const returnAssignments = callbackBody.filter(n =>
+            n.type === 'ExpressionStatement' &&
+            n.expression.left.type === 'MemberExpression' &&
+            n.expression.left.object.name === returnArgument.name &&
+            scriptTypeMap[scriptType].entryPoints.includes(n.expression.left.property.name)
+          );
+          if (returnAssignments.length > 0) {
+            hasValidEntryPoint = true;
           }
         }
 

--- a/lib/rules/entry-points.js
+++ b/lib/rules/entry-points.js
@@ -61,6 +61,28 @@ module.exports = {
           }
         }
 
+        if (returnArgument && returnArgument.type === 'Identifier') {
+          for (let i = 0; i < callbackBody.length; i++) {
+            const childNode = callbackBody[i];
+
+            if (childNode.type !== 'ExpressionStatement') {
+              continue;
+            }
+
+            const expressionLeft = childNode.expression.left;
+
+            if (
+              expressionLeft.object.name === returnArgument.name &&
+              scriptTypeMap[scriptType].entryPoints.includes(expressionLeft.property.name) &&
+              (expressionLeft.property.type === 'Identifier' ||
+              expressionLeft.property.type === 'FunctionExpression')
+            ) {
+              hasValidEntryPoint = true;
+              break;
+            }
+          }
+        }
+
         if (!hasValidEntryPoint) {
           context.report({
             node: returnStatement || callback,

--- a/tests/rules/entry-points.js
+++ b/tests/rules/entry-points.js
@@ -81,6 +81,18 @@ ruleTester.run('entry-points', rule, {
         '  return { somethingElse: x };',
         '});'
       ].join('\n')
+    },
+    {
+      code: [
+        '/**',
+        ' * @NScriptType ClientScript',
+        ' */',
+        'define([], function() {',
+        '  var exports = {};',
+        '  exports.pageInit = x;',
+        '  return exports;',
+        '});'
+      ].join('\n')
     }
   ],
 
@@ -137,6 +149,19 @@ ruleTester.run('entry-points', rule, {
         '});'
       ].join('\n'),
       errors: [{ messageId: 'returnEntryPoint', data: { type: 'Restlet' }}]
+    },
+    {
+      code: [
+        '/**',
+        ' * @NScriptType ClientScript',
+        ' */',
+        'define([], function() {',
+        '  var exports = {};',
+        '  exports.notAnEntryPoint = x;',
+        '  return exports;',
+        '});'
+      ].join('\n'),
+      errors: [{ messageId: 'returnEntryPoint', data: { type: 'ClientScript' }}]
     }
   ]
 });

--- a/tests/rules/entry-points.js
+++ b/tests/rules/entry-points.js
@@ -162,6 +162,20 @@ ruleTester.run('entry-points', rule, {
         '});'
       ].join('\n'),
       errors: [{ messageId: 'returnEntryPoint', data: { type: 'ClientScript' }}]
+    },
+    {
+      code: [
+        '/**',
+        ' * @NScriptType ClientScript',
+        ' */',
+        'define([], function() {',
+        '  var exports = {};',
+        '  var notTheReturnObject = {};',
+        '  notTheReturnObject.pageInit = x;',
+        '  return exports;',
+        '});'
+      ].join('\n'),
+      errors: [{ messageId: 'returnEntryPoint', data: { type: 'ClientScript' }}]
     }
   ]
 });


### PR DESCRIPTION
Hi,

I've tried adding support for an alternative return syntax I've used in some SuiteScript projects

e.g. 

```
define([], function() {
  var exports = {};
  exports.pageInit = function() {};
  return exports;
})
```

I haven't worked with eslint rules before and might not have taken the best approach, so feel free to decline if it doesn't look correct