### PR TITLE
Added a new rule "no-module-extensions" to prevent filename extensions in modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Enable the rules that you would like to use.
 * [suitescript/no-extra-modules](docs/rules/no-extra-modules.md): Enforces equal number of module literals and identifiers
 * [suitescript/no-invalid-modules](docs/rules/no-invalid-modules.md): Enforces valid SuiteScript modules in `define` array
 * [suitescript/no-log-module](docs/rules/no-log-module.md): Restricts loading of the N/log module in favor of global `Log`
+* [suitescript/no-module-extensions](docs/rules/no-module-extensions.md): Enforces no filename extensions on module dependencies
 * [suitescript/script-type](docs/rules/script-type.md): Enforces valid `@NScriptType` tag values
 
 ## License

--- a/docs/rules/no-module-extensions.md
+++ b/docs/rules/no-module-extensions.md
@@ -1,0 +1,29 @@
+# suitescript/no-module-extensions
+
+Enforces no filename extensions on module dependencies.
+
+There appears to be a NetSuite bug that intermittently causes an error ("SuiteScript 2.1 entry point scripts must implement one script type function..") when attempting to upload script files that include dependencies with file extensions.
+
+## Rule Details
+
+:white_check_mark: The following pattern is **correct**:
+
+```js
+/* eslint suitescript/no-log-module: "error" */
+
+define(['./lib'], function(lib) {});
+```
+
+:x: The following pattern is **incorrect**:
+
+```js
+/* eslint suitescript/no-log-module: "error" */
+
+define(['./lib.js'], function(lib) {});
+```
+
+## Version
+
+This rule was introduced in version 1.0.3
+
+- [Rule source](../../lib/rules/no-module-extensions.js)

--- a/docs/rules/no-module-extensions.md
+++ b/docs/rules/no-module-extensions.md
@@ -2,14 +2,14 @@
 
 Enforces no filename extensions on module dependencies.
 
-There appears to be a NetSuite bug that intermittently causes an error ("SuiteScript 2.1 entry point scripts must implement one script type function..") when attempting to upload script files that include dependencies with file extensions.
+There appears to be a NetSuite bug that intermittently causes an error (`SuiteScript 2.1 entry point scripts must implement one script type function..`) when attempting to upload script files that include dependencies with file extensions.
 
 ## Rule Details
 
 :white_check_mark: The following pattern is **correct**:
 
 ```js
-/* eslint suitescript/no-log-module: "error" */
+/* eslint suitescript/no-module-extensions: "error" */
 
 define(['./lib'], function(lib) {});
 ```
@@ -17,7 +17,7 @@ define(['./lib'], function(lib) {});
 :x: The following pattern is **incorrect**:
 
 ```js
-/* eslint suitescript/no-log-module: "error" */
+/* eslint suitescript/no-module-extensions: "error" */
 
 define(['./lib.js'], function(lib) {});
 ```

--- a/docs/rules/no-module-extensions.md
+++ b/docs/rules/no-module-extensions.md
@@ -2,7 +2,7 @@
 
 Enforces no filename extensions on module dependencies.
 
-There appears to be a NetSuite bug that intermittently causes an error (`SuiteScript 2.1 entry point scripts must implement one script type function..`) when attempting to upload script files that include dependencies with file extensions.
+As of January 2021, there appears to be a NetSuite bug that intermittently causes an error (`SuiteScript 2.1 entry point scripts must implement one script type function..`) when attempting to upload script files that include dependencies with file extensions.
 
 ## Rule Details
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = {
     'log-args': require('./lib/rules/log-args'),
     'module-vars': require('./lib/rules/module-vars'),
     'no-amd-name': require('./lib/rules/no-amd-name'),
-    'entry-points': require('./lib/rules/entry-points')
+    'entry-points': require('./lib/rules/entry-points'),
+    'no-module-extensions': require('./lib/rules/no-module-extensions')
   }
 };

--- a/lib/rules/no-module-extensions.js
+++ b/lib/rules/no-module-extensions.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview Enforce no filename extensions on module dependencies
+ * @author Michoel Chaikin
+ */
+
+'use strict';
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+const moduleUtil = require('../util/modules');
+
+const INVALID_MODULE_REGEX = /\.js/;
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    messages: {
+      invalidModuleExtension: 'Module name should not include file extension \'{{ module }}\''
+    },
+    fixable: true
+  },
+
+  create: function(context) {
+    let invalidModuleNodes = [];
+
+    return {
+      'CallExpression[callee.name=define]': function(node) {
+        const modules = moduleUtil.getModules(node).list;
+
+        invalidModuleNodes = modules.filter(m => INVALID_MODULE_REGEX.test(m.name)).map(m => m.nodes.name);
+
+        for (const invalidModuleNode of invalidModuleNodes) {
+          context.report({
+            node: invalidModuleNode,
+            messageId: 'invalidModuleExtension',
+            data: {
+              module: invalidModuleNode.value
+            },
+            fix: function(fixer) {
+              const fixedModuleName = invalidModuleNode.raw.replace(INVALID_MODULE_REGEX, '');
+              return fixer.replaceText(invalidModuleNode, fixedModuleName);
+            }
+          });
+        }
+      }
+    };
+  }
+};

--- a/lib/util/modules.js
+++ b/lib/util/modules.js
@@ -34,7 +34,7 @@ function getModules(defineCallNode) {
 
     if (
       moduleList.type !== 'ArrayExpression' ||
-      callback.type !== 'FunctionExpression'
+      (callback.type !== 'FunctionExpression' && callback.type !== 'ArrowFunctionExpression')
     ) {
       return modules;
     }

--- a/tests/rules/no-module-extensions.js
+++ b/tests/rules/no-module-extensions.js
@@ -32,6 +32,9 @@ ruleTester.run('no-module-extensions', rule, {
     },
     {
       code: 'define([], function() {});'
+    },
+    {
+      code: 'define(["N/record", "./lib"], (record, lib) => {});'
     }
   ],
 
@@ -50,6 +53,11 @@ ruleTester.run('no-module-extensions', rule, {
       code: 'define(["./lib1", "./lib2.js"], function(lib1, lib2) {});',
       errors: [{ messageId: 'invalidModuleExtension', data: { module: './lib2.js' }}],
       output: 'define(["./lib1", "./lib2"], function(lib1, lib2) {});'
+    },
+    {
+      code: 'define(["./lib1", "./lib2.js"], (lib1, lib2) => {});',
+      errors: [{ messageId: 'invalidModuleExtension', data: { module: './lib2.js' }}],
+      output: 'define(["./lib1", "./lib2"], (lib1, lib2) => {});'
     }
   ]
 });

--- a/tests/rules/no-module-extensions.js
+++ b/tests/rules/no-module-extensions.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Enforce no filename extensions on module dependencies
+ * @author Michoel Chaikin
+ */
+
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../lib/rules/no-module-extensions');
+
+const parserOptions = {
+  ecmaVersion: 2015,
+  sourceType: 'module'
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('no-module-extensions', rule, {
+  valid: [
+    {
+      code: 'define(["./lib"], function(lib) {});'
+    },
+    {
+      code: 'define(["N/record", "./lib"], function(record, lib) {});'
+    },
+    {
+      code: 'define([], function() {});'
+    }
+  ],
+
+  invalid: [
+    {
+      code: 'define(["./lib.js"], function(lib) {});',
+      errors: [{ messageId: 'invalidModuleExtension', data: { module: './lib.js' }}],
+      output: 'define(["./lib"], function(lib) {});'
+    },
+    {
+      code: 'define([\'./lib.js\'], function(lib) {});',
+      errors: [{ messageId: 'invalidModuleExtension', data: { module: './lib.js' }}],
+      output: 'define([\'./lib\'], function(lib) {});'
+    },
+    {
+      code: 'define(["./lib1", "./lib2.js"], function(lib1, lib2) {});',
+      errors: [{ messageId: 'invalidModuleExtension', data: { module: './lib2.js' }}],
+      output: 'define(["./lib1", "./lib2"], function(lib1, lib2) {});'
+    }
+  ]
+});


### PR DESCRIPTION
I ran into a bug last week with NetSuite refusing to upload a script file, which I eventually figured out was caused by ".js" file extension on the module imports. I've created a new rule to catch this, including auto-fixing.

This PR also added support for arrow functions in the define for all modules related rules
