### PR TITLE
add N/recordContext module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ const moduleVarsConfig = {
   'N/portlet': 'portlet',
   'N/query': 'query',
   'N/record': 'record',
+  'N/recordContext': 'recordContext',
   'N/redirect': 'redirect',
   'N/render': 'render',
   'N/runtime': 'runtime',

--- a/lib/util/moduleNames.js
+++ b/lib/util/moduleNames.js
@@ -35,6 +35,7 @@ module.exports = [
   'N/portlet',
   'N/query',
   'N/record',
+  'N/recordContext',
   'N/redirect',
   'N/render',
   'N/runtime',


### PR DESCRIPTION
Fixed N/recordContext, which was not applicable, to be compatible.