### PR TITLE
Fix entry point validation for null scriptType

### DIFF
--- a/lib/rules/entry-points.js
+++ b/lib/rules/entry-points.js
@@ -15,7 +15,7 @@ module.exports = {
       let hasValidEntryPoint = false;
       let scriptType = getScriptType(context);
 
-      if (!scriptType.value || !scriptType.def) {
+      if (!scriptType || !scriptType.value || !scriptType.def) {
         return;
       }
 

--- a/tests/rules/entry-points.js
+++ b/tests/rules/entry-points.js
@@ -101,6 +101,16 @@ define([], function() {
 });
       `,
     },
+    {
+      code: `
+// no @NScriptType comment
+
+define([], function() {
+  return { foo: 'bar' };
+});
+      `,
+      // Should not error, since scriptType is null and rule should exit early
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Enhance validation in entry-points.js to handle cases where scriptType is null, preventing potential errors when accessing its properties. Fixes #24.